### PR TITLE
fix: add "oldest-supported-numpy" and remove numpy version range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel"] 
+requires = ["setuptools>=40.8.0", "wheel", "oldest-supported-numpy"] 
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,7 @@ if __name__ == '__main__':
               'setuptools_scm',
               'pytest-runner',
               'cython>=0.16',
-              'numpy>=1.15',
+              'numpy',
           ],
           package_data={
               'reacnetgenerator': ['static/webpack/bundle.html',

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ if __name__ == '__main__':
           packages=find_packages(),
           python_requires='~=3.6',
           install_requires=[
-              'numpy>=1.15', 'scipy>=0.20.1', 'networkx',
+              'numpy', 'scipy>=0.20.1', 'networkx',
               'matplotlib', 'hmmlearn>=0.2.1',
               'ase', 'scour', 'tqdm',
               'coloredlogs',


### PR DESCRIPTION
- chore(docker): base on nikolaik/python-nodejs
- use full image
- fix: add "oldest-supported-numpy" and remove numpy version range
