### PR TITLE
chore: stop openbabel logging

### DIFF
--- a/reacnetgenerator/_detect.py
+++ b/reacnetgenerator/_detect.py
@@ -40,6 +40,9 @@ from .dps import dps
 from .utils import WriteBuffer, listtobytes, run_mp, SharedRNGData
 
 
+openbabel.obErrorLog.StopLogging()
+
+
 class _Detect(SharedRNGData, metaclass=ABCMeta):
     """Detect molecules.
     


### PR DESCRIPTION
OpenBabel always throws a lot of warnings