### PR TITLE
deprecate base64 for compress block

### DIFF
--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -41,7 +41,6 @@ requirements:
     - tqdm
     - coloredlogs
     - lz4
-    - pybase64
     - requests
     - packaging
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ dependencies = [
     'tqdm',
     'coloredlogs',
     'pandas',
-    'pybase64',
     'lz4',
     'requests',
     "openbabel-wheel",

--- a/reacnetgenerator/__init__.py
+++ b/reacnetgenerator/__init__.py
@@ -24,7 +24,6 @@ import matplotlib as mpl
 mpl.use("svg")  # noqa
 import networkx  # avoid qhull library error
 
-from . import _logging
 from ._version import __version__
 from .reacnetgen import ReacNetGenerator
 

--- a/reacnetgenerator/_detect.py
+++ b/reacnetgenerator/_detect.py
@@ -152,7 +152,7 @@ class _Detect(SharedRNGData, metaclass=ABCMeta):
         # which cause the different bytes results from same bond-network.
         return list([b''.join((listtobytes(mol),
                                listtobytes([(int(i[0]), int(i[1]))
-                                           for i in bondlist]).replace(b'\n', b'\t'),
+                                           for i in bondlist]),
                                listtobytes([int(i[2]) for i in bondlist])
                                )) for mol, bondlist in zip(*dps(bond, level))])
 

--- a/reacnetgenerator/_draw.py
+++ b/reacnetgenerator/_draw.py
@@ -19,7 +19,6 @@ placement. Software: Practice and experince. 1991, 21(11),1129-1164.
 """
 
 import math
-import traceback
 from io import StringIO
 from itertools import permutations
 

--- a/reacnetgenerator/_matrix.py
+++ b/reacnetgenerator/_matrix.py
@@ -14,7 +14,12 @@ from collections import Counter
 import numpy as np
 import pandas as pd
 
-from .utils import WriteBuffer, bytestolist, SharedRNGData
+from .utils import (
+    WriteBuffer,
+    bytestolist,
+    SharedRNGData,
+    read_compressed_block,
+)
 
 
 class _GenerateMatrix(SharedRNGData):
@@ -106,9 +111,10 @@ class _GenerateMatrix(SharedRNGData):
         return searchedspecies
 
     def _printspecies(self):
-        with open(self.moleculetemp2filename, 'rb') as ft, WriteBuffer(open(self.speciesfilename, 'w')) as fw:
+        with open(self.moleculetemp2filename, 'rb') as ft, \
+             WriteBuffer(open(self.speciesfilename, 'w')) as fw:
             d = [Counter() for i in range(len(self.timestep))]
-            for name, line in zip(self.mname, itertools.zip_longest(*[ft] * 3)):
+            for name, line in zip(self.mname, itertools.zip_longest(*[read_compressed_block(ft)] * 4)):
                 for t in bytestolist(line[-1]).tolist():
                     d[t][name] += 1
             for t in range(len(self.timestep)):

--- a/tests/test.json
+++ b/tests/test.json
@@ -47,6 +47,28 @@
     },
     {
         "rngparams": {
+            "urls": [{
+                "fn": "dump.reaxc",
+                "url": [
+                    "https://bf.njzjz.win/reacnetgenerator/dump.reaxc"
+                ],
+                "sha256": "b797263a7fed7eb6ae9f76a884222290bcdea8d58bf9751f52c77f150859215e"
+            }],
+            "inputfilename": "dump.reaxc",
+            "atomname": [
+                "H",
+                "O"
+            ],
+            "inputfiletype": "dump",
+            "runHMM": false,
+            "miso": 1
+        },
+        "reaction_sha256": [
+            "ec826635846cbe4d70a2454056ae973aaaf2c7bb760514017ebd6c804a85b6c2"
+        ]
+    },
+    {
+        "rngparams": {
             "inputfilename": "xxx",
             "inputfiletype": "abc",
             "atomname": ["X"] 


### PR DESCRIPTION
Now we use the format of block: size + block, so we can easily read any blocks.

This commit also:
- removes pybase64 from dependencies
- adds tests for miso
- removes unused imports
- formats codes
